### PR TITLE
feat: Add Record Player, update visualizers, and add subtitle features

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -319,22 +319,25 @@ function App() {
             </header>
 
             <main className="flex-1 flex flex-col p-4 overflow-y-auto">
-                <div className="w-full max-w-7xl mx-auto flex flex-col items-center gap-4">
-                    <div style={wrapperStyle} className="flex items-center justify-center bg-black rounded-lg border border-gray-700 overflow-hidden">
-                        <div
-                            style={{
-                                ...visualizerContainerStyle,
-                                backgroundImage: isTransparentBg ? checkerboardUrl : 'none',
-                                backgroundSize: '20px 20px',
-                            }}
-                            className="relative shadow-2xl shadow-cyan-500/10"
-                        >
-                            <AudioVisualizer
-                                ref={canvasRef}
-                                analyser={analyser}
-                                audioRef={audioRef}
-                                visualizationType={visualizationType}
-                                isPlaying={true}
+                {!audioFile ? (
+                    <AudioUploader onFileSelect={handleFileSelect} />
+                ) : (
+                    <div className="w-full max-w-7xl mx-auto flex flex-col items-center gap-4">
+                        <div style={wrapperStyle} className="flex items-center justify-center bg-black rounded-lg border border-gray-700 overflow-hidden">
+                            <div
+                                style={{
+                                    ...visualizerContainerStyle,
+                                    backgroundImage: isTransparentBg ? checkerboardUrl : 'none',
+                                    backgroundSize: '20px 20px',
+                                }}
+                                className="relative shadow-2xl shadow-cyan-500/10"
+                            >
+                                <AudioVisualizer
+                                    ref={canvasRef}
+                                    analyser={analyser}
+                                    audioRef={audioRef}
+                                    visualizationType={visualizationType}
+                                    isPlaying={isPlaying}
                                     customText={customText}
                                     textColor={textColor}
                                     fontFamily={fontFamily}
@@ -434,6 +437,7 @@ function App() {
                             onEffectOffsetYChange={setEffectOffsetY}
                         />
                     </div>
+                )}
             </main>
             <footer className="w-full text-center p-4 text-gray-500 text-sm flex-shrink-0">
                 一個與 <a href="https://www.youtube.com/channel/UCZVT570EWJ64ibL-re9CFpQ" target="_blank" rel="noopener noreferrer" className="text-cyan-400 hover:underline">Sonic Pulse</a> 合作的專案成果。


### PR DESCRIPTION
This commit introduces a new 'Record Player' visualizer, modifies existing effects, and adds input validation and download functionality for subtitles.

- Adds the 'Record Player' (`唱片機`) visualizer with dynamic, music-reactive elements.
- Reverses the 'Monstercat' and 'Monstercat (Glitch)' visualizers to display high frequencies centrally.
- Removes the vertical shake from the 'CRT Glitch' effect.
- Implements a 'Download SRT' feature to convert and save subtitles.
- Adds a validation check in the UI to warn users about invalid LRC formatting in the subtitle text area.
- Fixes a regression where the `AudioUploader` component was not being rendered on initial load.